### PR TITLE
Update nmcli.py

### DIFF
--- a/library/nmcli.py
+++ b/library/nmcli.py
@@ -605,6 +605,9 @@ class Nmcli(object):
             cmd.append(self.ifname)
         elif self.cname is not None:
             cmd.append(self.cname)
+        if self.enabled is not None:
+            cmd.append('autoconnect')
+            cmd.append(self.enabled)
         if self.ip4 is not None:
             cmd.append('ip4')
             cmd.append(self.ip4)
@@ -617,9 +620,6 @@ class Nmcli(object):
         if self.gw6 is not None:
             cmd.append('gw6')
             cmd.append(self.gw6)
-        if self.enabled is not None:
-            cmd.append('autoconnect')
-            cmd.append(self.enabled)
         return cmd
 
     def modify_connection_team(self):
@@ -628,6 +628,9 @@ class Nmcli(object):
         cmd.append('con')
         cmd.append('mod')
         cmd.append(self.cname)
+        if self.enabled is not None:
+            cmd.append('autoconnect')
+            cmd.append(self.enabled)
         if self.ip4 is not None:
             cmd.append('ipv4.address')
             cmd.append(self.ip4)
@@ -646,9 +649,6 @@ class Nmcli(object):
         if self.dns6 is not None:
             cmd.append('ipv6.dns')
             cmd.append(self.dns6)
-        if self.enabled is not None:
-            cmd.append('autoconnect')
-            cmd.append(self.enabled)
             # Can't use MTU with team
         return cmd
 
@@ -707,18 +707,6 @@ class Nmcli(object):
             cmd.append(self.ifname)
         elif self.cname is not None:
             cmd.append(self.cname)
-        if self.ip4 is not None:
-            cmd.append('ip4')
-            cmd.append(self.ip4)
-        if self.gw4 is not None:
-            cmd.append('gw4')
-            cmd.append(self.gw4)
-        if self.ip6 is not None:
-            cmd.append('ip6')
-            cmd.append(self.ip6)
-        if self.gw6 is not None:
-            cmd.append('gw6')
-            cmd.append(self.gw6)
         if self.enabled is not None:
             cmd.append('autoconnect')
             cmd.append(self.enabled)
@@ -740,6 +728,18 @@ class Nmcli(object):
         if self.downdelay is not None:
             cmd.append('arp-ip-target')
             cmd.append(self.arp_ip_target)
+        if self.ip4 is not None:
+            cmd.append('ip4')
+            cmd.append(self.ip4)
+        if self.gw4 is not None:
+            cmd.append('gw4')
+            cmd.append(self.gw4)
+        if self.ip6 is not None:
+            cmd.append('ip6')
+            cmd.append(self.ip6)
+        if self.gw6 is not None:
+            cmd.append('gw6')
+            cmd.append(self.gw6)
         return cmd
 
     def modify_connection_bond(self):
@@ -748,6 +748,9 @@ class Nmcli(object):
         cmd.append('con')
         cmd.append('mod')
         cmd.append(self.cname)
+        if self.enabled is not None:
+            cmd.append('autoconnect')
+            cmd.append(self.enabled)
         if self.ip4 is not None:
             cmd.append('ipv4.address')
             cmd.append(self.ip4)
@@ -766,9 +769,6 @@ class Nmcli(object):
         if self.dns6 is not None:
             cmd.append('ipv6.dns')
             cmd.append(self.dns6)
-        if self.enabled is not None:
-            cmd.append('autoconnect')
-            cmd.append(self.enabled)
         return cmd
 
     def create_connection_bond_slave(self):
@@ -823,6 +823,9 @@ class Nmcli(object):
             cmd.append(self.ifname)
         elif self.cname is not None:
             cmd.append(self.cname)
+        if self.enabled is not None:
+            cmd.append('autoconnect')
+            cmd.append(self.enabled)
         if self.ip4 is not None:
             cmd.append('ip4')
             cmd.append(self.ip4)
@@ -835,9 +838,6 @@ class Nmcli(object):
         if self.gw6 is not None:
             cmd.append('gw6')
             cmd.append(self.gw6)
-        if self.enabled is not None:
-            cmd.append('autoconnect')
-            cmd.append(self.enabled)
         return cmd
 
     def modify_connection_ethernet(self):
@@ -849,6 +849,12 @@ class Nmcli(object):
         cmd.append('con')
         cmd.append('mod')
         cmd.append(self.cname)
+        if self.enabled is not None:
+            cmd.append('autoconnect')
+            cmd.append(self.enabled)
+        if self.mtu is not None:
+            cmd.append('802-3-ethernet.mtu')
+            cmd.append(self.mtu)
         if self.ip4 is not None:
             cmd.append('ipv4.address')
             cmd.append(self.ip4)
@@ -867,12 +873,6 @@ class Nmcli(object):
         if self.dns6 is not None:
             cmd.append('ipv6.dns')
             cmd.append(self.dns6)
-        if self.mtu is not None:
-            cmd.append('802-3-ethernet.mtu')
-            cmd.append(self.mtu)
-        if self.enabled is not None:
-            cmd.append('autoconnect')
-            cmd.append(self.enabled)
         return cmd
 
     def create_connection_bridge(self):


### PR DESCRIPTION
First of all, thanks for this module, it's really helpful.

Running some playbooks with Ansible I encountered some "Unexpected argument" that seemed to be related with the order in which some cmd.append statements were placed (e.g using autoconnect when creating a new ethernet connection). According to nmcli's man page in my CentOS 7, the COMMON_OPTIONS like autoconnect should be placed before IP_OPTIONS like ip4 or gw6 so I've moved autoconnect after conn_name statements. Also TYPE_SPECIFIC_OPTIONS like mtu orr miitool should be placed before IP_OPTIONS and then I've changed those accordingly.

I hope you find correct my proposal.

Cheers!
